### PR TITLE
Added more build-ignored packages

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Dec 10 15:16:35 CET 2014 - locilka@suse.com
+
+- Ignoring more packages that do not contain any AutoYaST support
+  during build to shorten the build cycle and to remove unneeded
+  dependencies
+- 3.1.0.1
+
+-------------------------------------------------------------------
 Thu Sep 19 15:56:38 UTC 2013 - lslezak@suse.cz
 
 - do not use *.spec.in template, use *.spec file with RPM macros

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        3.1.0
+Version:        3.1.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -27,7 +27,7 @@ Group:	        System/YaST
 License:        GPL-2.0+
 
 # FIXME: drop yast2-all-packages some day
-BuildRequires:	java2-devel-packages trang yast2-all-packages
+BuildRequires:	trang yast2-all-packages
 
 # not covered by yast2-all-packages
 BuildRequires:	yast2-online-update-configuration
@@ -52,6 +52,13 @@ BuildRequires:  yast2-core
 
 # To speedup && to easily recover from dependency hell
 #!BuildIgnore: yast2-pkg-bindings-devel-doc yast2-pkg-bindings zypper libzypp yast2-gtk yast2-qt yast2-ncurses yast2-qt-pkg yast2-ncurses-pkg
+
+# Yast packages without AutoYast support
+#!BuildIgnore: yast2-add-on-creator yast2-country-data yast2-firstboot yast2-live-installer yast2-product-creator yast2-trans-allpacks
+#!BuildIgnore: yast2-control-center yast2-control-center-gnome yast2-control-center-qt
+
+# Doc packages
+# !BuildIgnore: yast2-devel-doc yast2-inetd-doc yast2-installation-devel-doc yast2-network-devel-doc yast2-nis-server-devel-doc yast2-printer-devel-doc
 
 BuildArchitectures:	noarch
 


### PR DESCRIPTION
- Packages that do not contain any AutoYaST support
- To shorten the build cycle
- To remove unneeded dependencies
- To be less reliable on build-errors in other packages

Build time _before_ the change:

```
real    4m3.379s
user    1m1.396s
sys     0m15.361s
```

Build time _after_ the change:

```
real    3m28.300s
user    0m54.913s
sys     0m12.803s
```
