### PR TITLE
Replacing yast2-all-packages in BuildRequires with list of packages needed for build

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 19 14:30:21 CET 2014 - locilka@suse.com
+
+- Replacing dropped yast2-all-packages with list of packages
+  that contain RNG files needed for AutoYaST
+- 3.1.2
+
+-------------------------------------------------------------------
 Wed Dec 10 15:16:35 CET 2014 - locilka@suse.com
 
 - Ignoring more packages that do not contain any AutoYaST support

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Package `yast2-all-packages` will be dropped
- This PR replaces that with list of Yast packages that contain RNG files needed for AutoYaST
- Some Build-Ignores have been left there - for further clarification
- The new RPM still contains the very same list of files (except of S390)
