### PR TITLE
Include yast2-registration in SLE 12 GA

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 13 11:40:46 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix validation of AutoYaST schema (bsc#954412)
+- 3.1.0.2
+
+-------------------------------------------------------------------
 Wed Dec 10 15:16:35 CET 2014 - locilka@suse.com
 
 - Ignoring more packages that do not contain any AutoYaST support

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -37,7 +37,7 @@ BuildRequires:	yast2-online-update-configuration
 BuildRequires:  yast2-core
 
 # openSUSE does not contain the registration module
-%if %suse_version == 1315
+%if !0%{?is_opensuse}
 BuildRequires:  yast2-registration
 %endif
 

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        3.1.0.1
+Version:        3.1.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -35,6 +35,12 @@ BuildRequires:	yast2-online-update-configuration
 
 # yast2-core omited from some reason in buildservice, adding explicitly
 BuildRequires:  yast2-core
+
+# openSUSE does not contain the registration module
+%if %suse_version == 1315
+BuildRequires:  yast2-registration
+%endif
+
 #!BuildIgnore: yast2-build-test yast2-online-update
 
 # optimization suggested by AJ:


### PR DESCRIPTION
I'm not sure if I should use `%suse_version` but I tried to build this package with `osc` and `%sles_version` returned `0`.

Any hint about this?