### PR TITLE
Add ssh_import section

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  6 11:08:20 UTC 2016 - igonzalezsosa@suse.com
+
+- Add ssh_import section
+- 3.1.7
+
+-------------------------------------------------------------------
 Fri Nov 13 11:40:46 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix validation of AutoYaST schema (bsc#954412)

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        3.1.6
+Version:        3.1.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This section was added in this [yast-autoinstallation PR](https://github.com/yast/yast-autoinstallation/pull/218). I'm just adding this information to the changes file of yast2-schema. Is this the correct way? (the package was rebuilt anyway even without updating the version/changelog).