### PR TITLE
Add support to use partitioning elements from control file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.sub
 configure
 configure.ac
 depcomp
+doc/
 install-sh
 *.pot
 libtool
@@ -20,10 +21,17 @@ ltconfig
 ltmain.sh
 missing
 mkinstalldirs
-stamp-h*
 Makefile.am.common
+stamp-h*
+src/rnc/*.rnc
+src/rng/*.rng
+tmp.*
+testsuite/config
+testsuite/run
+testsuite/site.exp
+testsuite/yast2-schema.*
 *.ami
 *.bz2
 .dep
-tmp.*
 *.log
+.yardoc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-schema-image yast-travis-ruby
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-schema-image storage-ng-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   yast2-http-server \
   yast2-inetd \
   yast2-installation \
+  yast2-installation-control \
   yast2-iscsi-client \
   yast2-kdump \
   yast2-mail \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM yastdevel/ruby
+FROM yastdevel/storage-ng
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   autoyast2 \
   trang \
   yast2 \
-  yast2-add-on \
   yast2-audit-laf \
   yast2-auth-client \
   yast2-auth-server \
@@ -20,7 +19,6 @@ RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   yast2-installation \
   yast2-installation-control \
   yast2-iscsi-client \
-  yast2-kdump \
   yast2-mail \
   yast2-network \
   yast2-nfs-client \

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,8 @@ require "yast/rake"
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/
+  # Commit to the storage-ng project
+  conf.obs_project = "YaST:storage-ng"
+  # Make sure 'rake osc:sr' fails
+  conf.obs_sr_project = nil
 end

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -3,6 +3,8 @@ Mon May 15 10:51:42 UTC 2017 - igonzalezsosa@suse.com
 
 - Add support to use partitioning elements from control file
   in an AutoYaST profile
+- First storage-ng version: yast2-add-on and yast2-kdump support
+  is temporarily removed
 - 3.3.0
 
 -------------------------------------------------------------------

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -2,7 +2,7 @@
 Mon May 15 10:51:42 UTC 2017 - igonzalezsosa@suse.com
 
 - Add support to use partitioning elements from control file
-  in an AutoYaST profile
+  in an AutoYaST profile (bsc#1039481)
 - First storage-ng version: yast2-add-on and yast2-kdump support
   is temporarily removed
 - 3.3.0

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 15 10:51:42 UTC 2017 - igonzalezsosa@suse.com
+
+- Add support to use partitioning elements from control file
+  in an AutoYaST profile
+- 3.3.0
+
+-------------------------------------------------------------------
 Fri Nov  4 10:12:24 UTC 2016 - igonzalezsosa@suse.com
 
 - Add support to enable copy-on-write for Btrfs subvolumes

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -41,7 +41,8 @@ BuildRequires:	trang yast2-devtools yast2-testsuite
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 BuildRequires: autoyast2
 BuildRequires: yast2
-BuildRequires: yast2-add-on
+# FIXME: storage-ng
+# BuildRequires: yast2-add-on
 BuildRequires: yast2-audit-laf
 BuildRequires: yast2-auth-client
 BuildRequires: yast2-auth-server
@@ -58,7 +59,8 @@ BuildRequires: yast2-inetd
 BuildRequires: yast2-installation
 BuildRequires: yast2-installation-control
 BuildRequires: yast2-iscsi-client
-BuildRequires: yast2-kdump
+# FIXME: storage-ng
+# BuildRequires: yast2-kdump
 BuildRequires: yast2-mail
 BuildRequires: yast2-network
 BuildRequires: yast2-nfs-client

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        3.2.0
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -56,6 +56,7 @@ BuildRequires: yast2-ftp-server
 BuildRequires: yast2-http-server
 BuildRequires: yast2-inetd
 BuildRequires: yast2-installation
+BuildRequires: yast2-installation-control
 BuildRequires: yast2-iscsi-client
 BuildRequires: yast2-kdump
 BuildRequires: yast2-mail

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -59,7 +59,7 @@ BuildRequires: yast2-inetd
 BuildRequires: yast2-installation
 # yast2-installation-control contains a file with partitioning_elements that are reused
 # by AutoYaST.
-BuildRequires: yast2-installation-control
+BuildRequires: yast2-installation-control >= 3.3.0
 BuildRequires: yast2-iscsi-client
 # FIXME: storage-ng. To be enabled again when yast2-kdump is adapted to yast2-storage-ng.
 # BuildRequires: yast2-kdump

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -41,7 +41,7 @@ BuildRequires:	trang yast2-devtools yast2-testsuite
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 BuildRequires: autoyast2
 BuildRequires: yast2
-# FIXME: storage-ng
+# FIXME: storage-ng. To be enabled again when yast2-add-on is adapted to yast2-storage-ng.
 # BuildRequires: yast2-add-on
 BuildRequires: yast2-audit-laf
 BuildRequires: yast2-auth-client
@@ -57,9 +57,11 @@ BuildRequires: yast2-ftp-server
 BuildRequires: yast2-http-server
 BuildRequires: yast2-inetd
 BuildRequires: yast2-installation
+# yast2-installation-control contains a file with partitioning_elements that are reused
+# by AutoYaST.
 BuildRequires: yast2-installation-control
 BuildRequires: yast2-iscsi-client
-# FIXME: storage-ng
+# FIXME: storage-ng. To be enabled again when yast2-kdump is adapted to yast2-storage-ng.
 # BuildRequires: yast2-kdump
 BuildRequires: yast2-mail
 BuildRequires: yast2-network


### PR DESCRIPTION
Add `yast2-installation-control` as a dependency so AutoYaST and control schemas can share the partitioning elements. See https://github.com/yast/yast-installation-control/pull/42 and https://github.com/imobachgs/yast-autoinstallation/pull/1.