### PR TITLE
use docker image from OBS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yastdevel/ruby
+FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   autoyast2 \
   trang \


### PR DESCRIPTION
For https://trello.com/c/sVVOXYbx/878-5-build-the-docker-images-for-travis-in-obs.
