### PR TITLE
Merge bsc#1156905 fix into SLE-15-GA

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 18 16:26:07 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix 'firstboot' and 'scripts' elements validation (bsc#1156905).
+- 4.0.4
+
+-------------------------------------------------------------------
 Wed May 23 06:49:24 UTC 2018 - igonzalezsosa@suse.com
 
 - Add create_subvolumes element (bsc#1094307)

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,7 +39,7 @@ BuildRequires:	trang yast2-devtools yast2-testsuite
 
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
-BuildRequires: autoyast2
+BuildRequires: autoyast2 >= 4.0.70
 BuildRequires: yast2
 BuildRequires: yast2-add-on
 BuildRequires: yast2-audit-laf
@@ -50,7 +50,7 @@ BuildRequires: yast2-country
 BuildRequires: yast2-dhcp-server
 BuildRequires: yast2-dns-server
 BuildRequires: yast2-firewall
-BuildRequires: yast2-firstboot
+BuildRequires: yast2-firstboot >= 4.0.9
 BuildRequires: yast2-ftp-server
 BuildRequires: yast2-http-server
 BuildRequires: yast2-installation


### PR DESCRIPTION
This PR merges the fix for bsc#1156905 into `SLE-15-GA`. However, it ignores the CPU mitigation settings as they are not included in yast2-bootloader for `SLE-15-GA`.