### PR TITLE
Merge bsc#1156905 fix into SLE-15-SP1

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Nov 18 16:26:07 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix 'scripts' elements validation (bsc#1156905).
+- 4.1.8
+
+-------------------------------------------------------------------
 Tue May  7 09:17:36 CEST 2019 - schubi@suse.de
 
 - Updated build requ. due tag cpu_mitigations in bootloader.

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.1.7
+Version:        4.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,7 +39,7 @@ BuildRequires:	trang yast2-devtools yast2-testsuite
 
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
-BuildRequires: autoyast2 >= 4.1.3
+BuildRequires: autoyast2 >= 4.1.8
 BuildRequires: yast2
 BuildRequires: yast2-add-on
 BuildRequires: yast2-audit-laf


### PR DESCRIPTION
See https://github.com/yast/yast-schema/pull/69.

* The yast2-firstboot problem was fixed back in 2018 (see [bsc#1117068](https://bugzilla.suse.com/show_bug.cgi?id=1117068)).
* The *scripts* section problem remained (see https://github.com/yast/yast-autoinstallation/pull/560).