### PR TITLE
Support for optional string and map types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   autoyast2 \
+  libxml2-tools \
   jing \
   trang \
   yast2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   autoyast2 \
+  jing \
   trang \
   yast2 \
   yast2-add-on \

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -2,6 +2,7 @@
 Thu May  7 16:13:37 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow optional types for string and map objects (bsc#1170886).
+- Check schema correctness with jing and xmllint (bsc#1172131).
 - 4.3.0
 
 -------------------------------------------------------------------

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May  7 16:13:37 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow optional types for string and map objects (bsc#1170886).
+- 4.3.0
+
+-------------------------------------------------------------------
 Fri Apr 17 12:02:29 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Exclude the registration for architectures on which it does not

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -30,6 +30,7 @@ Url:            https://github.com/yast/yast-schema
 
 # Dependencies needed to build the package
 BuildRequires:  jing
+BuildRequires:  libxml2-tools
 BuildRequires:	trang yast2-devtools
 
 # All packages providing RNG files for AutoYaST

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -29,6 +29,7 @@ License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-schema
 
 # Dependencies needed to build the package
+BuildRequires:  jing
 BuildRequires:	trang yast2-devtools
 
 # All packages providing RNG files for AutoYaST

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.2.10
+Version:        4.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -38,20 +38,21 @@ BuildRequires:	trang yast2-devtools
 BuildRequires: autoyast2 >= 4.2.25
 BuildRequires: yast2
 # add_on_others element
-BuildRequires: yast2-add-on >= 4.2.4
-BuildRequires: yast2-audit-laf
-BuildRequires: yast2-auth-client
+BuildRequires: yast2-add-on >= 4.3.0
+BuildRequires: yast2-audit-laf >= 4.3.0
+BuildRequires: yast2-auth-client >= 4.3.0
 BuildRequires: yast2-auth-server
 # tag secure_boot
-BuildRequires: yast2-bootloader >= 4.2.11
-BuildRequires: yast2-country
-BuildRequires: yast2-configuration-management >= 4.1.2
-BuildRequires: yast2-dhcp-server
-BuildRequires: yast2-dns-server
-BuildRequires: yast2-firewall >= 4.1.8
-BuildRequires: yast2-firstboot >= 4.1.1
-BuildRequires: yast2-ftp-server
+BuildRequires: yast2-bootloader >= 4.3.0
+BuildRequires: yast2-country >= 4.3.0
+BuildRequires: yast2-configuration-management >= 4.3.0
+BuildRequires: yast2-dhcp-server >= 4.3.0
+BuildRequires: yast2-dns-server >= 4.3.0
+BuildRequires: yast2-firewall >= 4.3.0
+BuildRequires: yast2-firstboot >= 4.3.0
+BuildRequires: yast2-ftp-server >= 4.3.0
 BuildRequires: yast2-tftp-server >= 4.1.7
+BuildRequires: yast2-geo-cluster >= 4.3.0
 BuildRequires: yast2-http-server
 BuildRequires: yast2-installation
 BuildRequires: yast2-iscsi-client

--- a/src/rng/Makefile.am
+++ b/src/rng/Makefile.am
@@ -19,6 +19,7 @@ clean-local:
 # Test with a minimal valid profile that the schema is correct
 check-local:
 	echo '<profile xmlns="http://www.suse.com/1.0/yast2ns"/>' | jing profile.rng /dev/stdin
+	echo '<profile xmlns="http://www.suse.com/1.0/yast2ns"/>' | xmllint --noout --relaxng profile.rng /dev/stdin
 
 install-data-local:
 	$(INSTALL) -d $(DESTDIR)$(schemadir)/autoyast/rng

--- a/src/rng/Makefile.am
+++ b/src/rng/Makefile.am
@@ -16,6 +16,10 @@ profile.rng: $(RNCS)
 clean-local:
 	rm -rf *.rng
 
+# Test with a minimal valid profile that the schema is correct
+check-local:
+	echo '<profile xmlns="http://www.suse.com/1.0/yast2ns"/>' | jing profile.rng /dev/stdin
+
 install-data-local:
 	$(INSTALL) -d $(DESTDIR)$(schemadir)/autoyast/rng
 	$(INSTALL) -m 644 *.rng $(DESTDIR)$(schemadir)/autoyast/rng


### PR DESCRIPTION
Update `BuildRequires` dependencies. Please, do not merge this PR until all modules are adapted.

Trello: https://trello.com/c/HkFkUQHj/1791-3-continue-with-new-xml-parser-xml-validation
Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1170886

To fix up things properly, all of these are needed together:
-  yast2-schema         https://github.com/yast/yast-schema/pull/76
-  yast2-geo-cluster    https://github.com/yast/yast-geo-cluster/pull/29
-  autoyast2            https://github.com/yast/yast-autoinstallation/pull/619
-  yast2-samba-server   https://github.com/yast/yast-samba-server/pull/81 (resolved: ~~but it won't build without  https://github.com/yast/yast-samba-server/pull/82 which it has a conflicting changelog with~~)
