### PR TITLE
Fix xmllint messages for invalid profiles by removing SL9.3 compatibility (bsc#1172578)

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jun  5 14:58:19 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Remove SUSE Linux 9.3 compatibility to improve error messages
+  (bsc#1172578)
+- Fix Jenkins build running into a Java out of memory error
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 16:13:37 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow optional types for string and map objects (bsc#1170886).

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -18,7 +18,8 @@ rm -f $RNC_OUTPUT/includes.rnc
 cp $COMMON $RNC_OUTPUT
 
 
-# initialize
+# Formerly the elements were sorted in these 2 categories but that
+# distinction is obsolete except in this script
 install=""
 configure=""
 

--- a/src/profile.rnc.templ
+++ b/src/profile.rnc.templ
@@ -6,28 +6,9 @@ include "common.rnc"
 include "includes.rnc"
 
 include "classes-use.rnc"
-## shared elements that haven't been split yet
-#include "profile-misc.rnc"
-
-configure_contents = CONFIGURE_RESOURCE
-install_contents = classes? & INSTALL_RESOURCE
-
-profile_resource = classes? & CONFIGURE_RESOURCE & INSTALL_RESOURCE
 
 profile = element profile {
-   profile_compatibility_sl93 |
-#   profile_current
-   profile_resource
+   classes? & CONFIGURE_RESOURCE & INSTALL_RESOURCE
 }
-
-profile_compatibility_sl93 =
-   element configure {
-       configure_contents
-   }? &
-   element install {
-       install_contents
-   }?
-
-profile_current = configure_contents & install_contents
 
 start = profile

--- a/src/rng/Makefile.am
+++ b/src/rng/Makefile.am
@@ -4,6 +4,11 @@
 RNCDIR=../rnc
 RNCS=$(wildcard $(RNCDIR)/*.rnc)
 
+# Decrease some JRE space to fit in limited memory on ci.opensuse.org
+# Prevents "Could not allocate metaspace: 1073741824 bytes"
+# https://rce-docs.hmdc.harvard.edu/faq/why-do-i-get-java-error-could-not-reserve-enough-space-object-heap
+export _JAVA_OPTIONS="-XX:CompressedClassSpaceSize=200M"
+
 all-local: profile.rng rules.rng classes-decl.rng
 profile.rng: $(RNCS)
 	trang -I rnc -O rng $(RNCDIR)/profile.rnc $@


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1172578
- Also, fix Jenkins build running into a Java out of memory error. Example of failed build: https://ci.opensuse.org/view/Yast/job/yast-yast-schema-master/40/console

<details>
<summary>SUSE Linux 9.3 was released in 2005. Expand this section to see the details of the compatibility mechanism.</summary>
For an example profile looking like this:

```xml
<profile>
  <general>...</general>
  <report>...</report>
  <users>...</users>
</profile
```

SUSE Linux 9.3 required the elements to be categorized as "install" or
"configure", like this:

```xml
<profile>
  <install>
    <general>...</general>
    <report>...</report>
  </install>
  <configure>
    <users>...</users>
  </configure>
</profile
```

but that complicates the schema just enough so that xmllint error messages for an invalid profile are *completely* useless, instead of just confusing.
</details>

This simplification will fix the error message when an unknown child of the root element is seen, and on lower levels will report at least the parent.

Example of a valid profile. (It is not actually useful, because the schema is too lenient)

```console
$ echo '<profile xmlns="http://www.suse.com/1.0/yast2ns">
> <add-on/>
> <software/>
> </profile>' | 
> xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /dev/stdin
/dev/stdin validates
```

How this helps.

<table>
<tr><th>invalid-1st-level.xml</th><th>invallid-2nd-level.xml<th></tr>
<tr><td>

```xml
<profile xmlns="http://www.suse.com/1.0/yast2ns">
  <add-on/>
  <bogus/>
</profile>
```
</td><td>

```xml
<profile xmlns="http://www.suse.com/1.0/yast2ns">
  <add-on/>
  <software><bogus/></software>
</profile>
```

</td></tr>
</table>

<details>
<summary>(command to produce the following diff)</summary>

```sh
for DOC in invalid-*xml; do 
    for SCHEMA in 1-before 2-after; do
        xmllint --noout --relaxng /tmp/$SCHEMA/profile.rng $DOC >& $DOC-$SCHEMA.out
    done
    diff -u9 $DOC-*.out
done
```

</details>

```diff
--- invalid-1st-level.xml-1-before.out (timestamps omitted)
+++ invalid-1st-level.xml-2-after.out
@@ -1,2 +1,2 @@
-invalid-1st-level.xml:2: element add-on: Relax-NG validity error : Element profile has extra content: add-on
+invalid-1st-level.xml:3: element bogus: Relax-NG validity error : Element profile has extra content: bogus
 invalid-1st-level.xml fails to validate
--- invalid-2nd-level.xml-1-before.out
+++ invalid-2nd-level.xml-2-after.out
@@ -1,2 +1,3 @@
-invalid-2nd-level.xml:2: element add-on: Relax-NG validity error : Element profile has extra content: add-on
+Relax-NG validity error : Extra element software in interleave
+invalid-2nd-level.xml:3: element software: Relax-NG validity error : Element profile failed to validate content
 invalid-2nd-level.xml fails to validate
```