### PR TITLE
Fix add-on schema

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 14:07:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the schema definition for the add_on_products and
+  add_on_others elements (boo#1174424).
+- 4.3.4
+
+-------------------------------------------------------------------
 Thu Jul  2 19:13:36 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Make the report section elements optional as AutoYaST proposes

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -39,8 +39,8 @@ BuildRequires:	trang yast2-devtools
 # make report elements and descendants optional
 BuildRequires: autoyast2 >= 4.3.20
 BuildRequires: yast2
-# add_on_others element
-BuildRequires: yast2-add-on >= 4.3.0
+# add_on_products and add_on_others types
+BuildRequires: yast2-add-on >= 4.3.3
 BuildRequires: yast2-audit-laf >= 4.3.0
 BuildRequires: yast2-auth-client >= 4.3.0
 BuildRequires: yast2-auth-server

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Update the schema to include the fix from https://github.com/yast/yast-add-on/pull/100.

Trello: https://trello.com/c/WtDObsGz/1983-3-tw-1174424-build-20200720-autoyast-profile-doesnt-validate
Bug report: https://bugzilla.opensuse.org/show_bug.cgi?id=1174424