### PR TITLE
[bsc#1175682] Element release_type is not mandatory

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug 24 11:38:34 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Element 'release_type' is not mandatory (bsc#1175682).
+- 4.3.5
+
+-------------------------------------------------------------------
 Tue Jul 28 14:07:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the schema definition for the add_on_products and

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.4
+Version:        4.3.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -72,7 +72,8 @@ BuildRequires: yast2-printer
 BuildRequires: yast2-proxy
 # registration is available only where suse connect is also available
 %ifnarch s390 %ix86
-BuildRequires: yast2-registration
+# release_type element is not mandatory
+BuildRequires: yast2-registration >= 4.3.8
 %endif
 # Package available for S390 only
 %ifarch s390 s390x


### PR DESCRIPTION
Update yast2-registration dependency to include [bsc#1175682 fix](https://github.com/yast/yast-registration/pull/507).