### PR TITLE
Recognize installed_product{,_version} in rules.xml

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep  2 15:14:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Recognize installed_product and installed_product_version as
+  legal elements of rules.xml files (boo#1176089).
+- 4.3.6
+
+-------------------------------------------------------------------
 Mon Aug 24 11:38:34 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Element 'release_type' is not mandatory (bsc#1175682).

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# make report elements and descendants optional
-BuildRequires: autoyast2 >= 4.3.20
+# proper validation of installed{,_version} elements in rules.xml
+BuildRequires: autoyast2 >= 4.3.43
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3


### PR DESCRIPTION
Update schema to solve [boo#1176089](https://bugzilla.opensuse.org/show_bug.cgi?id=1176089).

See https://github.com/yast/yast-autoinstallation/pull/683.