### PR TITLE
Fix general mode validation

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  1 08:11:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add validation of 'activate_systemd_default_target' and
+  'final_restart_services' elements in the 'general/mode' section.
+  (bsc#1176595).
+- 4.3.11
+
+-------------------------------------------------------------------
 Tue Sep 29 13:24:26 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Drop the 'suse_btrfs' element from the schema (bsc#1176970).

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# drop 'mouse' element
-BuildRequires: autoyast2 >= 4.3.55
+# 'activated_systemd_default_target' and 'final_restart_services' in 'general/mode'
+BuildRequires: autoyast2 >= 4.3.57
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Counterpart of https://github.com/yast/yast-autoinstallation/pull/714.

Partially fixes [bsc#1176595](https://bugzilla.suse.com/show_bug.cgi?id=1176595) by adding missing elements to the general/mode element.