### PR TITLE
Ignore unknown top-level sections

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  1 12:51:56 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not validate unknown sections (bsc#1177173).
+- 4.3.12
+
+-------------------------------------------------------------------
 Thu Oct  1 08:11:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add validation of 'activate_systemd_default_target' and

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -100,7 +100,6 @@ echo >&2 "known:     $known"
 # escape the connector for sed: & -> \&
 install="${install//&/\\&}"
 configure="${configure//&/\\&}"
-known="${known//|/\\|}"
 
 # add those components we have found
 sed -e "s/CONFIGURE_RESOURCE/${configure}/" \

--- a/src/profile.rnc.templ
+++ b/src/profile.rnc.templ
@@ -7,8 +7,12 @@ include "includes.rnc"
 
 include "classes-use.rnc"
 
+any_content = any_element* & text
+any_element = element * - (KNOWN_RESOURCE) { any_attribute*, any_content }
+any_attribute = attribute * { text }
+
 profile = element profile {
-   classes? & CONFIGURE_RESOURCE & INSTALL_RESOURCE
+   classes? & CONFIGURE_RESOURCE & INSTALL_RESOURCE & any_content?
 }
 
 start = profile


### PR DESCRIPTION
This PR solves [bsc#1177173](https://bugzilla.suse.com/show_bug.cgi?id=1177173). The idea is ignoring any 'top-level' element during validation.

```xml
<profile>
  <users t="list">
    <!-- this content gets validated -->
  </users>

  <sap-inst>
    <!-- sap-inst is not in the schema, so it does not get validated -->
  </sap-inst>
</profile>
```

`runlevel` and `classes` are handled a special because they are hardcoded into `runlevels.rnc` (xslt) and `classes-use.rnc` files.

How to match arbitrary content: http://www.microhowto.info/howto/match_arbitrary_content_using_relax_ng.html.