### PR TITLE
Fix string/symbol and 'masquerade_user' validation

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct  9 05:58:37 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST schema (bsc#1174133, bsc#1177496):
+  - Fix validation of string/symbol elements in the schema.
+  - Fix validation of 'masquerade_user' elements.
+- 4.3.13
+
+-------------------------------------------------------------------
 Thu Oct  1 12:51:56 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not validate unknown sections (bsc#1177173).

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -59,7 +59,7 @@ BuildRequires: yast2-http-server
 BuildRequires: yast2-installation
 BuildRequires: yast2-iscsi-client
 BuildRequires: yast2-kdump
-BuildRequires: yast2-mail
+BuildRequires: yast2-mail >= 4.3.3
 # setup_before_proposal element
 BuildRequires: yast2-network >= 4.3.10
 BuildRequires: yast2-nfs-client

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.12
+Version:        4.3.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Includes fixes from https://github.com/yast/yast-mail/pull/57 into the schema.