### PR TITLE
Registration/Addons: Architecture and version is optional.

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 20 16:15:12 CEST 2020 - schubi@suse.de
+
+- Registration/Addons: Architecture and version is optional.
+  (jsc#SLE-16225)
+- 4.3.15
+
+-------------------------------------------------------------------
 Tue Oct 13 10:12:16 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow setting the 't' (or 'config:type') attribute in:

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Tue Oct 20 16:15:12 CEST 2020 - schubi@suse.de
 
-- Registration/Addons: Architecture and version is optional.
+- Registration/Addons: Architecture and version are optional.
   (jsc#SLE-16225)
 - 4.3.15
 

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -72,8 +72,8 @@ BuildRequires: yast2-printer
 BuildRequires: yast2-proxy
 # registration is available only where suse connect is also available
 %ifnarch s390 %ix86
-# release_type element is not mandatory
-BuildRequires: yast2-registration >= 4.3.8
+# addons: architecture/version is optional
+BuildRequires: yast2-registration >= 4.3.12
 %endif
 # Package available for S390 only
 %ifarch s390 s390x


### PR DESCRIPTION
The arch/version tag in the registration section of AY configuration file is now optional. Adapting the requirements in order to enforce a rebuild of yast2-schema.