### PR TITLE
Add the reference for the Epic task in Jira

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -2,7 +2,7 @@
 Tue Oct 20 16:15:12 CEST 2020 - schubi@suse.de
 
 - Registration/Addons: Architecture and version are optional.
-  (jsc#SLE-16225)
+  (jsc#SLE-16195).
 - 4.3.15
 
 -------------------------------------------------------------------


### PR DESCRIPTION
According to the comment in [sr#229003](https://build.suse.de/request/show/229003), we should use the reference to the Epic entry in Jira.