### PR TITLE
 Add Btrfs quotas support

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 14 10:21:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for Btrfs quotas (jsc#SLE-7742).
+- 4.3.16
+
+-------------------------------------------------------------------
 Tue Oct 20 16:15:12 CEST 2020 - schubi@suse.de
 
 - Registration/Addons: Architecture and version are optional.

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.15
+Version:        4.3.16
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# set 't' element in 'backup' and 'upgrade' elements
-BuildRequires: autoyast2 >= 4.3.61
+# 'quotas' and 'referenced_limit' elements (jsc#SLE-7742)
+BuildRequires: autoyast2 >= 4.3.64
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3


### PR DESCRIPTION
Extend schema to support Btrfs quotas: See https://github.com/yast/yast-storage-ng/pull/1186 and https://github.com/yast/yast-autoinstallation/pull/723 for reference.