### PR TITLE
Add the 'lladdr' element to the networking interface section

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Tue Feb  2 07:39:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-- Add networking interface section 'lladdr' element (bsc#1179876)
+- Add the 'lladdr' element to the networking interface section
+  (bsc#1179876).
 - 4.3.17
 
 -------------------------------------------------------------------

--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb  2 07:39:54 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Add networking interface section 'lladdr' element (bsc#1179876)
+- 4.3.17
+
+-------------------------------------------------------------------
 Mon Dec 14 10:21:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for Btrfs quotas (jsc#SLE-7742).

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.16
+Version:        4.3.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -60,8 +60,8 @@ BuildRequires: yast2-installation
 BuildRequires: yast2-iscsi-client
 BuildRequires: yast2-kdump
 BuildRequires: yast2-mail >= 4.3.3
-# setup_before_proposal element
-BuildRequires: yast2-network >= 4.3.10
+# interface section 'lladdr' element
+BuildRequires: yast2-network >= 4.3.43
 BuildRequires: yast2-nfs-client
 BuildRequires: yast2-nfs-server
 BuildRequires: yast2-nis-client


### PR DESCRIPTION
It updates the schema dependency for https://github.com/yast/yast-network/pull/1157

- https://trello.com/c/lS5KY6FR/2254-2-sles15-sp3-p5-1179876-sles-15-sp3-beta1-lladdr-option-in-autoyast-control-file-is-invalid