### PR TITLE
Update dependencies on autoyast2 and yast2-network

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Mar 11 15:53:02 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Allow the interfaces list in the profile to be  empty
+  (bsc#1183257).
+- Remove the 'haspcmica' element from the schema (related to
+  bsc#1183352).
+- 4.3.21
+
+-------------------------------------------------------------------
 Wed Mar  3 15:33:51 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Allow using 'zone' instead of 'listentry' in the list of zones

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# 'quotas' and 'referenced_limit' elements (jsc#SLE-7742)
-BuildRequires: autoyast2 >= 4.3.64
+# remove the 'haspcmica' element
+BuildRequires: autoyast2 >= 4.3.71
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3
@@ -62,8 +62,8 @@ BuildRequires: yast2-installation
 BuildRequires: yast2-iscsi-client >= 4.3.3
 BuildRequires: yast2-kdump
 BuildRequires: yast2-mail >= 4.3.3
-# add 'bridge_forward_delay' element
-BuildRequires: yast2-network >= 4.3.51
+# allow interfaces list to be empty
+BuildRequires: yast2-network >= 4.3.56
 BuildRequires: yast2-nfs-client
 BuildRequires: yast2-nfs-server
 BuildRequires: yast2-nis-client


### PR DESCRIPTION
Integrate https://github.com/yast/yast-network/pull/1183 and https://github.com/yast/yast-autoinstallation/pull/740.

See [bsc#1183257](https://bugzilla.suse.com/show_bug.cgi?id=1183257) and [bsc#1183352](https://bugzilla.suse.com/show_bug.cgi?id=1183352).