### PR TITLE
 Support `static_text` in `ask/type`

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 11 11:35:36 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Consider 'static_text' as a valid value for 'ask/type' elements
+  (bsc#1185909).
+- 4.3.23
+
+-------------------------------------------------------------------
 Mon Apr  5 08:49:43 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add the 'mkfs_options' element to the 'partition' section

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.22
+Version:        4.3.23
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# add the 'mkfs_options' element
-BuildRequires: autoyast2 >= 4.3.77
+# update <ask> section: add 'static_text' as a possible value for the 'ask/type' element
+BuildRequires: autoyast2 >= 4.3.79
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3


### PR DESCRIPTION
Allow setting `static_text` as the value `ask/type` elements. See [bsc#1185909](https://bugzilla.opensuse.org/show_bug.cgi?id=1185909).

See https://github.com/yast/yast-autoinstallation/pull/758.