### PR TITLE
Merge SLE-15-SP2

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul  9 14:22:21 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add missing elements to rules.xml schema:
+  - installed_product and installed_product_version (boo#1176089)
+  - dialog section (bsc#1188153)
+- 4.3.24
+
+-------------------------------------------------------------------
 Tue May 11 11:35:36 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Consider 'static_text' as a valid value for 'ask/type' elements

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.23
+Version:        4.3.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# update <ask> section: add 'static_text' as a possible value for the 'ask/type' element
-BuildRequires: autoyast2 >= 4.3.79
+# add missing elements to rules.xml schema
+BuildRequires: autoyast2 >= 4.3.85
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3


### PR DESCRIPTION
Merge #110 and #111 into `SLE-15-SP3`. Tests are failing because autoyast2 is not available yet as an RPM (see https://github.com/yast/yast-autoinstallation/pull/777).