### PR TITLE
split package

### DIFF
--- a/RPMNAME
+++ b/RPMNAME
@@ -1,1 +1,1 @@
-yast2-schema
+yast2-schema-default

--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Tue Jan 25 14:21:41 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
-- Split package to yast2-schema-full and yast2-schema-micro to
-  respect limited set of modules in Micro product (jsc#SLE-18820)
+- Split the package into yast2-schema-default and
+  yast2-schema-micro to respect limited set of modules in Micro
+  product (jsc#SLE-18820)
 - 4.4.9
 
 -------------------------------------------------------------------

--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 25 14:21:41 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Split package to yast2-schema-full and yast2-schema-micro to
+  respect limited set of modules in Micro product (jsc#SLE-18820)
+- 4.4.9
+
+-------------------------------------------------------------------
 Tue Jan 11 06:03:29 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added lsm 'none' section to the security schema (jsc#SLE-22069)

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package yast2-schema
+# spec file for package yast2-schema-default
 #
 # Copyright (c) 2013 SUSE LINUX Products GmbH, Nuernberg, Germany.
 #
@@ -16,9 +16,9 @@
 #
 
 
-Name:           yast2-schema
+Name:           yast2-schema-default
 # Keep versions in sync with yast2-schema-micro
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -28,6 +28,10 @@ Group:	        System/YaST
 License:        GPL-2.0-or-later
 
 Url:            https://github.com/yast/yast-schema
+
+Provides:       yast2-schema
+Conflicts:      yast2-schema-micro
+Obsoletes:      yast2-schema < 4.4.9
 
 # Dependencies needed to build the package
 BuildRequires:  jing

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -30,7 +30,8 @@ License:        GPL-2.0-or-later
 Url:            https://github.com/yast/yast-schema
 
 Provides:       yast2-schema
-Conflicts:      yast2-schema-micro
+# others cannot be used as it contains same files
+Conflicts:      otherproviders(yast2-schema)
 Obsoletes:      yast2-schema < 4.4.9
 
 # Dependencies needed to build the package

--- a/package/yast2-schema-micro.changes
+++ b/package/yast2-schema-micro.changes
@@ -8,4 +8,4 @@ Wed Jan 19 14:16:09 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - initial package to have dedicated limited schema for Micro
   product (jsc#SLE-18820)
-- 4.4.8
+- 4.4.9

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -21,7 +21,9 @@ Version:        4.4.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-Source0:        yast2-schema-%{version}.tar.bz2
+# source to generate rpm is same as with default, just limited set of build depedencies
+# results in limited profile
+Source0:        yast2-schema-default-%{version}.tar.bz2
 
 URL:            https://github.com/yast/yast-schema
 
@@ -86,14 +88,14 @@ Group:          System/YaST
 AutoYaST Syntax Schema for Micro product
 
 %prep
-%setup -n yast2-schema-%{version}
+%setup -n yast2-schema-default-%{version}
 
 %build
 %yast_build
 
 %install
 %yast_install
-rm -rf %{buildroot}/%{_docdir}/yast2-schema
+rm -rf %{buildroot}/%{_docdir}/yast2-schema-default
 
 %files
 %defattr(-,root,root)

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -29,9 +29,9 @@ URL:            https://github.com/yast/yast-schema
 
 # provide schema, so it is full replacement
 Provides:       yast2-schema
-# both cannot be used as it uses same files
-Conflicts:      yast2-schema-default
-Obsoletes:       yast2-schema < 4.4.9
+# others cannot be used as it contains same files
+Conflicts:      otherproviders(yast2-schema)
+Obsoletes:      yast2-schema < 4.4.9
 
 # Dependencies needed to build the package
 BuildRequires:  jing

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -28,7 +28,8 @@ URL:            https://github.com/yast/yast-schema
 # provide schema, so it is full replacement
 Provides:       yast2-schema
 # both cannot be used as it uses same files
-Conflicts:      yast2-schema
+Conflicts:      yast2-schema-default
+Obsolets:       yast2-schema < 4.4.9
 
 # Dependencies needed to build the package
 BuildRequires:  jing

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -29,7 +29,7 @@ URL:            https://github.com/yast/yast-schema
 Provides:       yast2-schema
 # both cannot be used as it uses same files
 Conflicts:      yast2-schema-default
-Obsolets:       yast2-schema < 4.4.9
+Obsoletes:       yast2-schema < 4.4.9
 
 # Dependencies needed to build the package
 BuildRequires:  jing


### PR DESCRIPTION
Feature: Micro product does not contain autoyast second stage, so its set of packages are limited.

Implementation: Split schema package to default and micro and both provides yast2-schema, so build dependencies should be correct.