### PR TITLE
Drop YaST NIS dependencies from TW

### DIFF
--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Mar 28 08:23:33 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Remove dependency of YaST NIS packages from TW (bsc#1183893).
+
+-------------------------------------------------------------------
 Fri Feb 18 14:35:23 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added fcoe-client schema (bsc#1194895)

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -74,8 +74,11 @@ BuildRequires: yast2-mail >= 4.3.3
 BuildRequires: yast2-network >= 4.4.29
 BuildRequires: yast2-nfs-client
 BuildRequires: yast2-nfs-server
+# YaST NIS packages are dropped from TW (bsc#1183893)
+%if 0%{?suse_version} > 1500
 BuildRequires: yast2-nis-client
 BuildRequires: yast2-nis-server
+%endif
 BuildRequires: yast2-ntp-client
 BuildRequires: yast2-online-update-configuration
 BuildRequires: yast2-printer


### PR DESCRIPTION
## Problem

YaST NIS packages (i.e., *yast2-nis-server* and *yast2-nis-client*) were dropped from TW, see https://github.com/yast/yast-nis-server/pull/30 and https://github.com/yast/yast-nis-client/pull/63. But *yast2-schema-default* still depends on such packages.

## Solution

Drop dependency from TW package.

Note: This PR will not be merged into master yet. The temporary branch pre-SLE-15-SP4 will be merged into master after SLE-15-SP4 branching. Do not forget to bump the version while merging.