### PR TITLE
bsc#1199165: fix rules syntax

### DIFF
--- a/package/yast2-schema.changes
+++ b/package/yast2-schema.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May  4 05:46:40 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix rules validation when using a dialog (bsc#1199165).
+- 4.3.29
+
+-------------------------------------------------------------------
 Fri Feb 18 14:35:23 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added fcoe-client schema (bsc#1194895)

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema
-Version:        4.3.28
+Version:        4.3.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-schema.spec
+++ b/package/yast2-schema.spec
@@ -36,8 +36,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# add 'keep_unknown_lv' element to the partitioning schema
-BuildRequires: autoyast2 >= 4.3.91
+# fix 'rules' validation ('conflicts' and 'dialog')
+BuildRequires: autoyast2 >= 4.3.102
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3


### PR DESCRIPTION
Related to [bsc#1199165](https://bugzilla.suse.com/1199165). The original problem is fixed by:

* https://github.com/yast/yast-autoinstallation/pull/836
* https://github.com/yast/yast-autoinstallation/pull/837. This PR contains a few examples about how the validation is expected to work.