### PR TITLE
Sychronize default and micro packages

### DIFF
--- a/package/yast2-schema-micro.changes
+++ b/package/yast2-schema-micro.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May  4 05:46:40 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix rules validation when using a dialog (bsc#1199165).
+- 4.4.12
+
+-------------------------------------------------------------------
 Fri Feb 18 14:35:52 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Added fcoe-client schema (bsc#1194895)

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,8 +39,8 @@ BuildRequires:  libxml2-tools
 BuildRequires:  trang
 BuildRequires:  yast2-devtools
 
-# use SLE15 SP3 Update dependencies as micro is based on SP3
-BuildRequires:  autoyast2 >= 4.3.94
+# fix 'rules' validation ('conflicts' and 'dialog')
+BuildRequires: autoyast2 >= 4.4.37
 BuildRequires:  yast2
 BuildRequires:  yast2-add-on >= 4.3.3
 # set 't' element in 'initrd_module' element


### PR DESCRIPTION
## Problem

I forgot to update the spec and changes file for the `-micro` package in #134.

## Solution

Keep `-default` and `-micro` packages synchronized.

