### PR TITLE
Update build network dependency for micro

### DIFF
--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -52,7 +52,8 @@ BuildRequires:  yast2-iscsi-client >= 4.3.3
 # Added fcoe-client schema
 BuildRequires: yast2-fcoe-client >= 4.3.1
 BuildRequires:  yast2-kdump
-BuildRequires:  yast2-network >= 4.3.81
+# add route 'extrapara' element
+BuildRequires:  yast2-network >= 4.4.48
 # registration is available only where suse connect is also available
 %ifnarch s390 %ix86
 # addons: architecture/version is optional


### PR DESCRIPTION
Added missing build network dependency for #142 (needed by https://github.com/yast/yast-network/pull/1299)
