### PR TITLE
Bump version and update changelog

### DIFF
--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 12 11:33:31 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Add KDUMP_AUTO_RESIZE element in kdump section
+ (related to jsc#SLE-18441 and gh#yast/yast-kdump#123).
+- 4.5.5
+
+-------------------------------------------------------------------
 Mon Jul  4 13:20:29 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Add 'extrapara' to routes in the networking section (bsc#1201129)

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-schema-default
 # Keep versions in sync with yast2-schema-micro
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

Schema for kdump was updated at https://github.com/yast/yast-kdump/pull/123 but yast2-schema has not been re-built yet. Thus, profiles using KDUMP_AUTO_RESIZE will not pass validations. See https://bugzilla.suse.com/show_bug.cgi?id=1202360

## Solution

Bump package version to rebuilt it and to make available schema changes sent in yast2-kdump.

## Testing

Tested manually by building the package and installing it to check that a profile using KDUMP_AUTO_RESIZE is valid.
