### PR TITLE
drop yast2-sound from tw

### DIFF
--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 23 22:04:58 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- drop yast2-sound schema spec from TW where yast2-sound is dropped
+  (bsc#1206903)
+- 4.5.7
+
+-------------------------------------------------------------------
 Thu Nov  3 17:02:23 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for security policies validation (jsc#SLE-24764).

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-schema-default
 # Keep versions in sync with yast2-schema-micro
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -98,7 +98,10 @@ BuildRequires: yast2-samba-server
 # Add support for security policies ('security_policy')
 BuildRequires: yast2-security >= 4.5.3
 BuildRequires: yast2-services-manager
+# YaST sound packages are dropped from TW (bsc#1206903)
+%if 0%{?sle_version}
 BuildRequires: yast2-sound
+%endif
 BuildRequires: yast2-squid
 BuildRequires: yast2-sysconfig
 # tag home_btrfs_subvolume

--- a/package/yast2-schema-micro.changes
+++ b/package/yast2-schema-micro.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 23 22:04:58 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- drop yast2-sound schema spec from TW where yast2-sound is dropped
+  (bsc#1206903)
+- 4.5.7
+
+-------------------------------------------------------------------
 Thu Nov  3 17:02:23 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for security policies validation (jsc#SLE-24764).

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

yast2-sound will be soon dropped from TW (https://bugzilla.suse.com/show_bug.cgi?id=1206903)


## Solution

Drop dependency on it