### PR TITLE
Update SLE-15-SP6 dependencies to enforce update of the schema

### DIFF
--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 22 10:36:42 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added several LUKS-related elements to the partitioning schema
+  (jsc#PED-3878, jsc#PED-5518).
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-schema-default
 # Keep versions in sync with yast2-schema-micro
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -42,8 +42,8 @@ BuildRequires:	trang yast2-devtools
 # All packages providing RNG files for AutoYaST
 # in /usr/share/YaST2/schema/autoyast/rng/*.rng
 
-# fix 'rules' validation ('conflicts' and 'dialog')
-BuildRequires: autoyast2 >= 4.5.1
+# LUKS-related elements in the partitioning schema
+BuildRequires: autoyast2 >= 4.6.4
 BuildRequires: yast2
 # add_on_products and add_on_others types
 BuildRequires: yast2-add-on >= 4.3.3

--- a/package/yast2-schema-micro.changes
+++ b/package/yast2-schema-micro.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 22 10:38:20 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added several LUKS-related elements to the partitioning schema
+  (jsc#PED-3878, jsc#PED-5518).
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -39,8 +39,8 @@ BuildRequires:  libxml2-tools
 BuildRequires:  trang
 BuildRequires:  yast2-devtools
 
-# fix 'rules' validation ('conflicts' and 'dialog')
-BuildRequires: autoyast2 >= 4.5.1
+# LUKS-related elements in the partitioning schema
+BuildRequires: autoyast2 >= 4.6.4
 BuildRequires:  yast2
 BuildRequires:  yast2-add-on >= 4.3.3
 # set 't' element in 'initrd_module' element


### PR DESCRIPTION
## Problem

https://github.com/yast/yast-autoinstallation/pull/872 adds four new LUKS-related elements to the `<partition>` section of the schema. But that's not enough to make the change effective. The corresponding changes need to be enforced into yast2-schema by updating the versions in the dependency.

## Solution

This updates the dependency as needed to really incorporate the new elements to the schema.
