### PR TITLE
bump to fix kdump schema in backward compatible way

### DIFF
--- a/package/yast2-schema-default.changes
+++ b/package/yast2-schema-default.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 10 08:28:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Bump schema to adapt for version kdump versions 1.9+ (bsc#1212646) 
+- 4.6.2
+
+-------------------------------------------------------------------
 Fri Sep 22 10:36:42 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added several LUKS-related elements to the partitioning schema

--- a/package/yast2-schema-default.spec
+++ b/package/yast2-schema-default.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-schema-default
 # Keep versions in sync with yast2-schema-micro
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -72,7 +72,7 @@ BuildRequires: yast2-geo-cluster >= 4.3.0
 BuildRequires: yast2-installation
 # add 'iface' element
 BuildRequires: yast2-iscsi-client >= 4.3.3
-BuildRequires: yast2-kdump
+BuildRequires: yast2-kdump >= 4.6.1
 BuildRequires: yast2-mail >= 4.3.3
 # add route 'extrapara' element
 BuildRequires: yast2-network >= 4.5.4

--- a/package/yast2-schema-micro.changes
+++ b/package/yast2-schema-micro.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 10 08:28:42 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Bump schema to adapt for version kdump versions 1.9+ (bsc#1212646) 
+- 4.6.2
+
+-------------------------------------------------------------------
 Fri Sep 22 10:38:20 UTC 2023 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added several LUKS-related elements to the partitioning schema

--- a/package/yast2-schema-micro.spec
+++ b/package/yast2-schema-micro.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-schema-micro
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -51,7 +51,7 @@ BuildRequires:  yast2-country >= 4.3.0
 BuildRequires:  yast2-iscsi-client >= 4.3.3
 # Added fcoe-client schema
 BuildRequires: yast2-fcoe-client >= 4.3.1
-BuildRequires:  yast2-kdump
+BuildRequires:  yast2-kdump >= 4.6.1
 # add route 'extrapara' element
 BuildRequires:  yast2-network >= 4.5.4
 # registration is available only where suse connect is also available


### PR DESCRIPTION
## Problem

OpenQA fails: https://openqa.suse.de/tests/12788994#step/installation/125 (nonpublic link; "XML validation errors: ["ERROR: Extra element kdump in interleave", "169:0: ERROR: Element profile failed to validate content"]")

SP6 contain still old TW change to kdump that do backward incompatible changes to autoyast schema. Fix is already in SP6 kdump packages, but we need to rebuild schema.

https://github.com/yast/yast-kdump/pull/135

## Solution

Bump version.